### PR TITLE
Add store welcome panel

### DIFF
--- a/src/classes/class-admindashboard.php
+++ b/src/classes/class-admindashboard.php
@@ -64,12 +64,12 @@ namespace Niteo\WooCart\Defaults {
 							<p><?php esc_html_e( 'To start receiving payments, you\'ll need to set up a payment gateway.', 'woocart-defaults' ); ?></p>
 							<p><?php esc_html_e( 'Here are the instructions and the recommended plugins for the popular gateways:', 'woocart-defaults' ); ?></p>
 							<ul>
-								<li><a href="https://wordpress.org/plugins/paypal-for-woocommerce/" target="_blank"><?php esc_html_e( 'PayPal', 'woocart-defaults' ); ?></a></li>
-								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-stripe/" target="_blank"><?php esc_html_e( 'Stripe', 'woocart-defaults' ); ?></a></li>
-								<li><a href="https://wordpress.org/plugins/klarna-checkout-for-woocommerce/" target="_blank"><?php esc_html_e( 'Klarna', 'woocart-defaults' ); ?></a></li>
-								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-paypal-powered-by-braintree/" target="_blank"><?php esc_html_e( 'BrainTree', 'woocart-defaults' ); ?></a></li>
-								<li><a href="https://wordpress.org/plugins/paymill/" target="_blank"><?php esc_html_e( 'Paymill', 'woocart-defaults' ); ?></a></li>
-								<li><a href="https://wordpress.org/plugins/woocommerce-payu-paisa/" target="_blank"><?php esc_html_e( 'PayU', 'woocart-defaults' ); ?></a></li>
+								<li><a href="https://wordpress.org/plugins/paypal-for-woocommerce/" target="_blank">PayPal</a></li>
+								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-stripe/" target="_blank">Stripe</a></li>
+								<li><a href="https://wordpress.org/plugins/klarna-checkout-for-woocommerce/" target="_blank">Klarna</a></li>
+								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-paypal-powered-by-braintree/" target="_blank">BrainTree</a></li>
+								<li><a href="https://wordpress.org/plugins/paymill/" target="_blank">Paymill</a></li>
+								<li><a href="https://wordpress.org/plugins/woocommerce-payu-paisa/" target="_blank">PayU</a></li>
 							</ul>
 						</div>
 					</div>
@@ -81,9 +81,9 @@ namespace Niteo\WooCart\Defaults {
 							<p><?php esc_html_e( 'If you prepare shipping slips automatically, you\'ll need to use a shipping courier plugin.', 'woocart-defaults' ); ?></p>
 							<p><?php esc_html_e( 'Here are the recommended plugins for the most popular couriers:', 'woocart-defaults' ); ?></p>
 							<ul>
-								<li><a href="https://wordpress.org/plugins/dhl-for-woocommerce/" target="_blank"><?php esc_html_e( 'DHL', 'woocart-defaults' ); ?></a></li>
-								<li><a href="https://woocommerce.com/products/fedex-shipping-module/" target="_blank"><?php esc_html_e( 'FedEx', 'woocart-defaults' ); ?></a></li>
-								<li><a href="https://wordpress.org/plugins/flexible-shipping-ups/" target="_blank"><?php esc_html_e( 'UPS', 'woocart-defaults' ); ?></a></li>
+								<li><a href="https://wordpress.org/plugins/dhl-for-woocommerce/" target="_blank">DHL</a></li>
+								<li><a href="https://woocommerce.com/products/fedex-shipping-module/" target="_blank">FedEx</a></li>
+								<li><a href="https://wordpress.org/plugins/flexible-shipping-ups/" target="_blank">UPS</a></li>
 							</ul>
 						</div>
 					</div>

--- a/src/classes/class-admindashboard.php
+++ b/src/classes/class-admindashboard.php
@@ -93,7 +93,14 @@ namespace Niteo\WooCart\Defaults {
 							<!-- Add your products -->
 							<h3><?php esc_html_e( 'Add Your Products', 'woocart-defaults' ); ?></h3>
 							<p><?php printf( 
-								__('Add your products manually or import a CSV with the <a href="%s">WooCommerce import</a>.', 'woocart-defaults' ),
+								wp_kses(
+									__( 'Add your products manually or import a CSV with the <a href="%s">WooCommerce import</a>.', 'woocart-defaults' ),
+									array(
+										'a' => array(
+											'href' => array()
+										)
+									)
+								),
 								esc_url(
 									get_admin_url( null, 'edit.php?post_type=product&page=product_importer' )
 								)

--- a/src/classes/class-admindashboard.php
+++ b/src/classes/class-admindashboard.php
@@ -64,12 +64,12 @@ namespace Niteo\WooCart\Defaults {
 							<p><?php esc_html_e( 'To start receiving payments, you\'ll need to set up a payment gateway.', 'woocart-defaults' ); ?></p>
 							<p><?php esc_html_e( 'Here are the instructions and the recommended plugins for the popular gateways:', 'woocart-defaults' ); ?></p>
 							<ul>
-								<li><a href="https://wordpress.org/plugins/paypal-for-woocommerce/" target="_blank">PayPal</a></li>
-								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-stripe/" target="_blank">Stripe</a></li>
-								<li><a href="https://wordpress.org/plugins/klarna-checkout-for-woocommerce/" target="_blank">Klarna</a></li>
-								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-paypal-powered-by-braintree/" target="_blank">BrainTree</a></li>
-								<li><a href="https://wordpress.org/plugins/paymill/" target="_blank">Paymill</a></li>
-								<li><a href="https://wordpress.org/plugins/woocommerce-payu-paisa/" target="_blank">PayU</a></li>
+								<li><a href="https://wordpress.org/plugins/paypal-for-woocommerce/" target="_blank" rel="noopener noreferrer">PayPal</a></li>
+								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-stripe/" target="_blank" rel="noopener noreferrer">Stripe</a></li>
+								<li><a href="https://wordpress.org/plugins/klarna-checkout-for-woocommerce/" target="_blank" rel="noopener noreferrer">Klarna</a></li>
+								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-paypal-powered-by-braintree/" target="_blank" rel="noopener noreferrer">BrainTree</a></li>
+								<li><a href="https://wordpress.org/plugins/paymill/" target="_blank" rel="noopener noreferrer">Paymill</a></li>
+								<li><a href="https://wordpress.org/plugins/woocommerce-payu-paisa/" target="_blank" rel="noopener noreferrer">PayU</a></li>
 							</ul>
 						</div>
 					</div>
@@ -81,9 +81,9 @@ namespace Niteo\WooCart\Defaults {
 							<p><?php esc_html_e( 'If you prepare shipping slips automatically, you\'ll need to use a shipping courier plugin.', 'woocart-defaults' ); ?></p>
 							<p><?php esc_html_e( 'Here are the recommended plugins for the most popular couriers:', 'woocart-defaults' ); ?></p>
 							<ul>
-								<li><a href="https://wordpress.org/plugins/dhl-for-woocommerce/" target="_blank">DHL</a></li>
-								<li><a href="https://woocommerce.com/products/fedex-shipping-module/" target="_blank">FedEx</a></li>
-								<li><a href="https://wordpress.org/plugins/flexible-shipping-ups/" target="_blank">UPS</a></li>
+								<li><a href="https://wordpress.org/plugins/dhl-for-woocommerce/" target="_blank" rel="noopener noreferrer">DHL</a></li>
+								<li><a href="https://woocommerce.com/products/fedex-shipping-module/" target="_blank" rel="noopener noreferrer">FedEx</a></li>
+								<li><a href="https://wordpress.org/plugins/flexible-shipping-ups/" target="_blank" rel="noopener noreferrer">UPS</a></li>
 							</ul>
 						</div>
 					</div>
@@ -114,7 +114,16 @@ namespace Niteo\WooCart\Defaults {
 						<div class="welcome-panel-inner">
 							<!-- Logo & slider banners -->
 							<h3><?php esc_html_e( 'Add Your Own Logo and Slider Banners', 'woocart-defaults' ); ?></h3>
-							<p><?php printf( esc_html__( 'You\'ll want to add your own logo and banners to the store. You can use something like %sthe free tool Canva%s to create these graphics.', 'woocart-defaults' ), '<a href="https://www.canva.com/create/banners/" target="_blank">', '</a>' ); ?></p>
+							<p><?php echo wp_kses(
+								__( 'You\'ll want to add your own logo and banners to the store. You can use something like %sthe free tool <a href="https://www.canva.com/create/banners/" target="_blank" rel="noopener noreferrer">Canva</a> to create these graphics.', 'woocart-defaults' ),
+								array(
+									'a' => array(
+										'href' 		=> array(),
+										'target' 	=> array(),
+										'rel' 		=> array()
+									)
+								)
+							); ?></p>
 							<ul>
 								<li><a href="<?php echo esc_url( get_admin_url( null, 'customize.php' ) ); ?>"><?php esc_html_e( 'Start Customizing', 'woocart-defaults' ); ?></a></li>
 							</ul>

--- a/src/classes/class-admindashboard.php
+++ b/src/classes/class-admindashboard.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Handles content for the admin dashboard panel.
+ *
+ * @category   Plugins
+ * @package    WordPress
+ * @subpackage woocart-defaults
+ * @since      1.0.0
+ */
+
+namespace Niteo\WooCart\Defaults {
+
+
+	/**
+	 * Class AdminDashboard
+	 *
+	 * @package Niteo\WooCart\Defaults
+	 */
+	class AdminDashboard {
+
+		/**
+		 * AdminDashboard constructor.
+		 */
+		public function __construct() {
+			add_action( 'admin_init', array( &$this, 'init' ) );
+		}
+
+		/**
+		 * Get fired once the admin panel initializes.
+		 */
+		public function init() {
+			if ( is_admin() ) {
+				remove_action( 'welcome_panel', 'wp_welcome_panel' );
+				add_action( 'welcome_panel', array( &$this, 'welcome_panel' ) );
+			}
+		}
+
+		/**
+		 * Our customised welcome panel for the store.
+		 */
+		public function welcome_panel() {
+			?>
+			<style>
+				.welcome-panel-content .welcome-panel-column .welcome-panel-inner,
+				.welcome-panel-content h2,
+				.welcome-panel-content .about-description {
+					padding: 0 10px;
+				}
+			</style>
+
+			<div class="welcome-panel-content">
+				<h2><?php esc_html_e( 'Welcome to your new store!', 'woocart-defaults' ); ?></h2>
+				<p class="about-description"><?php esc_html_e( 'You are only a few steps away from selling.', 'woocart-defaults' ); ?></p>
+
+				<div class="welcome-panel-column-container">
+					<div class="welcome-panel-column">
+						<div class="welcome-panel-inner">
+							<!-- Connect a payment gateway -->
+							<h3><?php esc_html_e( 'Connect a Payment Gateway', 'woocart-defaults' ); ?></h3>
+							<p><?php esc_html_e( 'To start receiving payments, you\'ll need to set up a payment gateway.', 'woocart-defaults' ); ?></p>
+							<p><?php esc_html_e( 'Here are the instructions and the recommended plugins for the popular gateways:', 'woocart-defaults' ); ?></p>
+							<ul>
+								<li><a href="https://wordpress.org/plugins/paypal-for-woocommerce/" target="_blank"><?php esc_html_e( 'PayPal', 'woocart-defaults' ); ?></a></li>
+								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-stripe/" target="_blank"><?php esc_html_e( 'Stripe', 'woocart-defaults' ); ?></a></li>
+								<li><a href="https://wordpress.org/plugins/klarna-checkout-for-woocommerce/" target="_blank"><?php esc_html_e( 'Klarna', 'woocart-defaults' ); ?></a></li>
+								<li><a href="https://wordpress.org/plugins/woocommerce-gateway-paypal-powered-by-braintree/" target="_blank"><?php esc_html_e( 'BrainTree', 'woocart-defaults' ); ?></a></li>
+								<li><a href="https://wordpress.org/plugins/paymill/" target="_blank"><?php esc_html_e( 'Paymill', 'woocart-defaults' ); ?></a></li>
+								<li><a href="https://wordpress.org/plugins/woocommerce-payu-paisa/" target="_blank"><?php esc_html_e( 'PayU', 'woocart-defaults' ); ?></a></li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="welcome-panel-column">
+						<div class="welcome-panel-inner">
+							<!-- Connect a shipping courier -->
+							<h3><?php esc_html_e( 'Connect a Shipping Courier', 'woocart-defaults' ); ?></h3>
+							<p><?php esc_html_e( 'If you prepare shipping slips automatically, you\'ll need to use a shipping courier plugin.', 'woocart-defaults' ); ?></p>
+							<p><?php esc_html_e( 'Here are the recommended plugins for the most popular couriers:', 'woocart-defaults' ); ?></p>
+							<ul>
+								<li><a href="https://wordpress.org/plugins/dhl-for-woocommerce/" target="_blank"><?php esc_html_e( 'DHL', 'woocart-defaults' ); ?></a></li>
+								<li><a href="https://woocommerce.com/products/fedex-shipping-module/" target="_blank"><?php esc_html_e( 'FedEx', 'woocart-defaults' ); ?></a></li>
+								<li><a href="https://wordpress.org/plugins/flexible-shipping-ups/" target="_blank"><?php esc_html_e( 'UPS', 'woocart-defaults' ); ?></a></li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="welcome-panel-column welcome-panel-last">
+						<div class="welcome-panel-inner">
+							<!-- Add your products -->
+							<h3><?php esc_html_e( 'Add Your Products', 'woocart-defaults' ); ?></h3>
+							<p><?php printf( esc_html__( 'Add your products manually or import a CSV with the %sWooCommerce import%s.', 'woocart-defaults' ), '<a href="' . esc_url( get_admin_url( null, 'edit.php?post_type=product&page=product_importer' ) ) . '">', '</a>' ); ?></p>
+						</div>
+					</div>
+				</div>
+
+				<div class="welcome-panel-column-container">
+					<div class="welcome-panel-column">
+						<div class="welcome-panel-inner">
+							<!-- Logo & slider banners -->
+							<h3><?php esc_html_e( 'Add Your Own Logo and Slider Banners', 'woocart-defaults' ); ?></h3>
+							<p><?php printf( esc_html__( 'You\'ll want to add your own logo and banners to the store. You can use something like %sthe free tool Canva%s to create these graphics.', 'woocart-defaults' ), '<a href="https://www.canva.com/create/banners/" target="_blank">', '</a>' ); ?></p>
+							<ul>
+								<li><a href="<?php echo esc_url( get_admin_url( null, 'customize.php' ) ); ?>"><?php esc_html_e( 'Start Customizing', 'woocart-defaults' ); ?></a></li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="welcome-panel-column welcome-panel-last">
+						<div class="welcome-panel-inner">
+							<!-- Test checkout -->
+							<h3><?php esc_html_e( 'Test The Checkout', 'woocart-defaults' ); ?></h3>
+							<p><?php esc_html_e( 'Go through the buying process and review that everything is working as it should.', 'woocart-defaults' ); ?></p>
+							<ul>
+								<li><a href="<?php echo esc_url( get_site_url() ); ?>" target="_blank"><?php esc_html_e( 'Visit Your Store', 'woocart-defaults' ); ?></a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</div>
+			<?php
+		}
+
+	}
+}

--- a/src/classes/class-admindashboard.php
+++ b/src/classes/class-admindashboard.php
@@ -46,6 +46,10 @@ namespace Niteo\WooCart\Defaults {
 				.welcome-panel-content .about-description {
 					padding: 0 10px;
 				}
+				.welcome-panel-content li {
+				    display: inline-block;
+				    margin-right: 13px;
+				}
 			</style>
 
 			<div class="welcome-panel-content">
@@ -88,7 +92,12 @@ namespace Niteo\WooCart\Defaults {
 						<div class="welcome-panel-inner">
 							<!-- Add your products -->
 							<h3><?php esc_html_e( 'Add Your Products', 'woocart-defaults' ); ?></h3>
-							<p><?php printf( esc_html__( 'Add your products manually or import a CSV with the %sWooCommerce import%s.', 'woocart-defaults' ), '<a href="' . esc_url( get_admin_url( null, 'edit.php?post_type=product&page=product_importer' ) ) . '">', '</a>' ); ?></p>
+							<p><?php printf( 
+								__('Add your products manually or import a CSV with the <a href="%s">WooCommerce import</a>.', 'woocart-defaults' ),
+								esc_url(
+									get_admin_url( null, 'edit.php?post_type=product&page=product_importer' )
+								)
+							); ?></p>
 						</div>
 					</div>
 				</div>

--- a/src/i18n/woocart-defaults.pot
+++ b/src/i18n/woocart-defaults.pot
@@ -1,25 +1,34 @@
-#, fuzzy
+# Copyright (C) 2018 WooCart
+# This file is distributed under the same license as the WooCart Defaults plugin.
 msgid ""
 msgstr ""
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-"Project-Id-Version: WooCart Defaults\n"
-"POT-Creation-Date: 2018-10-01 19:41+0530\n"
-"PO-Revision-Date: 2018-10-01 19:41+0530\n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"Project-Id-Version: WooCart Defaults @##VERSION##@\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/src\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.4\n"
-"X-Poedit-Basepath: ..\n"
-"X-Poedit-Flags-xgettext: --add-comments=translators:\n"
-"X-Poedit-WPHeader: index.php\n"
-"X-Poedit-SourceCharset: UTF-8\n"
-"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
-"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
-"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
-"X-Poedit-SearchPath-0: .\n"
-"X-Poedit-SearchPathExcluded-0: *.js\n"
+"POT-Creation-Date: 2018-10-01T22:24:00+05:30\n"
+"PO-Revision-Date: 2018-10-01T22:24:00+05:30\n"
+"X-Generator: WP-CLI 2.0.1\n"
+"X-Domain: woocart-defaults\n"
+
+#. Plugin Name of the plugin
+msgid "WooCart Defaults"
+msgstr ""
+
+#. Description of the plugin
+msgid "Manage and deploy WordPress + WooCommerce configuration changes."
+msgstr ""
+
+#. Author of the plugin
+msgid "WooCart"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "www.woocart.com"
+msgstr ""
 
 #: classes/class-admindashboard.php:56
 msgid "Welcome to your new store!"
@@ -38,9 +47,7 @@ msgid "To start receiving payments, you'll need to set up a payment gateway."
 msgstr ""
 
 #: classes/class-admindashboard.php:65
-msgid ""
-"Here are the instructions and the recommended plugins for the popular "
-"gateways:"
+msgid "Here are the instructions and the recommended plugins for the popular gateways:"
 msgstr ""
 
 #: classes/class-admindashboard.php:80
@@ -48,9 +55,7 @@ msgid "Connect a Shipping Courier"
 msgstr ""
 
 #: classes/class-admindashboard.php:81
-msgid ""
-"If you prepare shipping slips automatically, you'll need to use a shipping "
-"courier plugin."
+msgid "If you prepare shipping slips automatically, you'll need to use a shipping courier plugin."
 msgstr ""
 
 #: classes/class-admindashboard.php:82
@@ -62,53 +67,29 @@ msgid "Add Your Products"
 msgstr ""
 
 #: classes/class-admindashboard.php:97
-#, php-format
-msgid ""
-"Add your products manually or import a CSV with the <a href=\"%s"
-"\">WooCommerce import</a>."
+msgid "Add your products manually or import a CSV with the <a href=\"%s\">WooCommerce import</a>."
 msgstr ""
 
 #: classes/class-admindashboard.php:116
 msgid "Add Your Own Logo and Slider Banners"
 msgstr ""
 
-#: classes/class-admindashboard.php:117
-#, php-format
-msgid ""
-"You'll want to add your own logo and banners to the store. You can use "
-"something like %sthe free tool Canva%s to create these graphics."
-msgstr ""
-
-#: classes/class-admindashboard.php:119
-msgid "Start Customizing"
-msgstr ""
-
-#: classes/class-admindashboard.php:127
-msgid "Test The Checkout"
+#: classes/class-admindashboard.php:118
+msgid "You'll want to add your own logo and banners to the store. You can use something like %sthe free tool <a href=\"https://www.canva.com/create/banners/\" target=\"_blank\" rel=\"noopener noreferrer\">Canva</a> to create these graphics."
 msgstr ""
 
 #: classes/class-admindashboard.php:128
-msgid ""
-"Go through the buying process and review that everything is working as it "
-"should."
+msgid "Start Customizing"
 msgstr ""
 
-#: classes/class-admindashboard.php:130
+#: classes/class-admindashboard.php:136
+msgid "Test The Checkout"
+msgstr ""
+
+#: classes/class-admindashboard.php:137
+msgid "Go through the buying process and review that everything is working as it should."
+msgstr ""
+
+#: classes/class-admindashboard.php:139
 msgid "Visit Your Store"
-msgstr ""
-
-#. Plugin Name of the plugin/theme
-msgid "WooCart Defaults"
-msgstr ""
-
-#. Description of the plugin/theme
-msgid "Manage and deploy WordPress + WooCommerce configuration changes."
-msgstr ""
-
-#. Author of the plugin/theme
-msgid "WooCart"
-msgstr ""
-
-#. Author URI of the plugin/theme
-msgid "www.woocart.com"
 msgstr ""

--- a/src/i18n/woocart-defaults.pot
+++ b/src/i18n/woocart-defaults.pot
@@ -1,31 +1,114 @@
-# Copyright (C) 2018 WooCart
-# This file is distributed under the same license as the WooCart Defaults plugin.
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCart Defaults @##VERSION##@\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/src\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Project-Id-Version: WooCart Defaults\n"
+"POT-Creation-Date: 2018-10-01 19:41+0530\n"
+"PO-Revision-Date: 2018-10-01 19:41+0530\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2018-09-19T16:42:34+02:00\n"
-"PO-Revision-Date: 2018-09-19T16:42:34+02:00\n"
-"X-Generator: WP-CLI 2.0.1\n"
-"X-Domain: woocart-defaults\n"
+"X-Generator: Poedit 2.0.4\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-Flags-xgettext: --add-comments=translators:\n"
+"X-Poedit-WPHeader: index.php\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.js\n"
 
-#. Plugin Name of the plugin
+#: classes/class-admindashboard.php:56
+msgid "Welcome to your new store!"
+msgstr ""
+
+#: classes/class-admindashboard.php:57
+msgid "You are only a few steps away from selling."
+msgstr ""
+
+#: classes/class-admindashboard.php:63
+msgid "Connect a Payment Gateway"
+msgstr ""
+
+#: classes/class-admindashboard.php:64
+msgid "To start receiving payments, you'll need to set up a payment gateway."
+msgstr ""
+
+#: classes/class-admindashboard.php:65
+msgid ""
+"Here are the instructions and the recommended plugins for the popular "
+"gateways:"
+msgstr ""
+
+#: classes/class-admindashboard.php:80
+msgid "Connect a Shipping Courier"
+msgstr ""
+
+#: classes/class-admindashboard.php:81
+msgid ""
+"If you prepare shipping slips automatically, you'll need to use a shipping "
+"courier plugin."
+msgstr ""
+
+#: classes/class-admindashboard.php:82
+msgid "Here are the recommended plugins for the most popular couriers:"
+msgstr ""
+
+#: classes/class-admindashboard.php:94
+msgid "Add Your Products"
+msgstr ""
+
+#: classes/class-admindashboard.php:97
+#, php-format
+msgid ""
+"Add your products manually or import a CSV with the <a href=\"%s"
+"\">WooCommerce import</a>."
+msgstr ""
+
+#: classes/class-admindashboard.php:116
+msgid "Add Your Own Logo and Slider Banners"
+msgstr ""
+
+#: classes/class-admindashboard.php:117
+#, php-format
+msgid ""
+"You'll want to add your own logo and banners to the store. You can use "
+"something like %sthe free tool Canva%s to create these graphics."
+msgstr ""
+
+#: classes/class-admindashboard.php:119
+msgid "Start Customizing"
+msgstr ""
+
+#: classes/class-admindashboard.php:127
+msgid "Test The Checkout"
+msgstr ""
+
+#: classes/class-admindashboard.php:128
+msgid ""
+"Go through the buying process and review that everything is working as it "
+"should."
+msgstr ""
+
+#: classes/class-admindashboard.php:130
+msgid "Visit Your Store"
+msgstr ""
+
+#. Plugin Name of the plugin/theme
 msgid "WooCart Defaults"
 msgstr ""
 
-#. Description of the plugin
+#. Description of the plugin/theme
 msgid "Manage and deploy WordPress + WooCommerce configuration changes."
 msgstr ""
 
-#. Author of the plugin
+#. Author of the plugin/theme
 msgid "WooCart"
 msgstr ""
 
-#. Author URI of the plugin
+#. Author URI of the plugin/theme
 msgid "www.woocart.com"
 msgstr ""

--- a/src/index.php
+++ b/src/index.php
@@ -17,6 +17,7 @@ namespace Niteo\WooCart {
 
 	use Niteo\WooCart\Defaults\Filters;
 	use Niteo\WooCart\Defaults\Shortcodes;
+	use Niteo\WooCart\Defaults\AdminDashboard;
 
 	if ( class_exists( 'WP_CLI' ) ) {
 		\WP_CLI::add_command( 'wcd', __NAMESPACE__ . '\Defaults\CLI_Command' );
@@ -28,5 +29,12 @@ namespace Niteo\WooCart {
 
 	if ( function_exists( 'do_shortcode' ) ) {
 		new Filters();
+	}
+
+	/**
+	 * Panel for the store in the WP admin dashboard.
+	 */
+	if ( function_exists( 'add_action' ) ) {
+		new AdminDashboard();
 	}
 }

--- a/tests/AdminDashboardTest.php
+++ b/tests/AdminDashboardTest.php
@@ -1,0 +1,62 @@
+<?php
+
+
+use Niteo\WooCart\Defaults\AdminDashboard;
+use PHPUnit\Framework\TestCase;
+
+class AdminDashboardTest extends TestCase
+{
+    function setUp()
+    {
+        \WP_Mock::setUp();
+    }
+
+    function tearDown()
+    {
+        $this->addToAssertionCount(
+            \Mockery::getContainer()->mockery_getExpectationCount()
+        );
+        \WP_Mock::tearDown();
+        \Mockery::close();
+    }
+
+
+    /**
+     * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
+     */
+    public function testConstructor()
+    {
+        $dashboard = new AdminDashboard();
+        \WP_Mock::expectActionAdded( 'admin_init', [ $dashboard, 'init' ] );
+
+        $dashboard->__construct();
+        \WP_Mock::assertHooksAdded();
+    }
+
+    /**
+     * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
+     * @covers \Niteo\WooCart\Defaults\AdminDashboard::init
+     */
+    public function testInit()
+    {
+        $dashboard = new AdminDashboard();
+        \WP_Mock::expectActionAdded( 'welcome_panel', [ $dashboard, 'welcome_panel' ] );
+
+        \WP_Mock::wpFunction(
+            'remove_action', array(
+                'args' => array(
+                    'welcome_panel',
+                    'wp_welcome_panel'
+                )
+            )
+        );
+        \WP_Mock::wpFunction(
+            'is_admin', array(
+                'return' => true
+            )
+        );
+
+        $dashboard->init();
+        \WP_Mock::assertHooksAdded();
+    }
+}


### PR DESCRIPTION
Ref: https://github.com/niteoweb/woocart/issues/317

This PR adds the welcome panel for the store in the admin dashboard. The default welcome screen has been replaced with our custom welcome screen for the store.

The idea behind replacing the default welcome screen is that it focuses primarily on post and pages along with a few other links. Our customized welcome panel brings the focus back to store related stuff.