### PR TITLE
Update denylist

### DIFF
--- a/src/classes/class-denylist.php
+++ b/src/classes/class-denylist.php
@@ -248,7 +248,7 @@ namespace Niteo\WooCart\Defaults {
 			if ( $this->is_plugin_denied( $plugin ) ) {
 				return [
 					sprintf(
-						'<a href="javascript:;" title="%2$s">%1$s</a>',
+						'<a href="https://woocart.com/plugins-denylist" title="%2$s" target="_blank">%1$s</a>',
 						'Not available',
 						'This plugin is not allowed on our system due to performance, security, or compatibility concerns. Please contact our support with any questions.'
 					),

--- a/src/classes/class-denylist.php
+++ b/src/classes/class-denylist.php
@@ -159,6 +159,7 @@ namespace Niteo\WooCart\Defaults {
 			'wp-db-manager',
 			'file-manager-advanced',
 			'force-https-littlebizzy',
+			'wp-encrypt',
 		];
 
 		/**

--- a/src/classes/class-denylist.php
+++ b/src/classes/class-denylist.php
@@ -272,7 +272,7 @@ namespace Niteo\WooCart\Defaults {
 			&& $this->is_plugin_denied( $plugin )
 			) {
 				$links['activate'] = sprintf(
-					'<a href="javascript:;" data-plugin="%3$s" title="%2$s">%1$s</a>',
+					'<a href="https://woocart.com/plugins-denylist" data-plugin="%3$s" title="%2$s" target="_blank">%1$s</a>',
 					'Not available',
 					'This plugin is not allowed on our system due to performance, security, or compatibility concerns. Please contact our support with any questions.',
 					$plugin

--- a/tests/DenyListTest.php
+++ b/tests/DenyListTest.php
@@ -127,7 +127,7 @@ class DenyListTest extends TestCase
 
     $this->assertEquals(
       $denylist->disable_install_link( [], 'adminer' ),
-      [ '<a href="javascript:;" title="This plugin is not allowed on our system due to performance, security, or compatibility concerns. Please contact our support with any questions.">Not available</a>' ]
+      [ '<a href="https://woocart.com/plugins-denylist" title="This plugin is not allowed on our system due to performance, security, or compatibility concerns. Please contact our support with any questions." target="_blank">Not available</a>' ]
     );
   }
 
@@ -157,7 +157,7 @@ class DenyListTest extends TestCase
 
     $this->assertEquals(
       $denylist->disable_activate_link( [ 'activate' => '' ], 'adminer' ),
-      [ 'activate' => '<a href="javascript:;" data-plugin="adminer" title="This plugin is not allowed on our system due to performance, security, or compatibility concerns. Please contact our support with any questions.">Not available</a>' ]
+      [ 'activate' => '<a href="https://woocart.com/plugins-denylist" data-plugin="adminer" title="This plugin is not allowed on our system due to performance, security, or compatibility concerns. Please contact our support with any questions." target="_blank">Not available</a>' ]
     );
   }
 


### PR DESCRIPTION
This PR adds:

- **WP Encrypt** plugin to the `denylist`.
- Adds a link to the denylist page on WooCart on `Install` and `Activate` links.

This should be merged after [this PR](https://github.com/niteoweb/minisites/pull/263) is merged.